### PR TITLE
Winter war Soviet enforce surrender fix

### DIFF
--- a/common/decisions/SOV.txt
+++ b/common/decisions/SOV.txt
@@ -9265,7 +9265,7 @@ operations = {
 		}
 
 		cancel_trigger = {
-			NOT = { has_war_with = SOV }
+			NOT = { has_war_with = FIN }
 		}
 
 		days_remove = 7


### PR DESCRIPTION
The decision for the Soviets to enforce surrender on the Finish when they reach the requirement is broken because it will cancel after 1 day, this fixes that problem and should enforce the peace after the 7-day timer.