### PR TITLE
Fix to prevent rubber refs from being nuked

### DIFF
--- a/common/buildings/00_buildings.txt
+++ b/common/buildings/00_buildings.txt
@@ -174,6 +174,9 @@ buildings = {
 		value = 5
 		infrastructure_construction_effect = yes
 		
+		#this can be edited to 0.01 but lower will reduce the damage done to rubber refs.
+		damage_factor = 0.025
+		
 		show_modifier = yes
 	}
 	


### PR DESCRIPTION
The figure can be adjusted when needed, but it's a nice fix for now. It would take a lot of ic investment to successfully knock out a large portion of rubber refs and that is if it goes uncontested. So static AA and fighters will still be a more effective measure and may even prevent them from getting blown up completely.